### PR TITLE
chore: Access Secrets based on segregated environments

### DIFF
--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -11,11 +11,10 @@ on:
         required: true
         type: string
 
-  
+run-name: Deploy Spectre Node to Mainnet - ${{ inputs.release_tag }} by @${{ github.actor }}
+
 env:
-  AWS_REGION: '${{ secrets.AWS_REGION }}'
   ENVIRONMENT: MAINNET
-  AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
   REGISTRY: 'ghcr.io'
   VERSION: ${{ inputs.release_tag }}
   
@@ -23,12 +22,14 @@ jobs:
   deploy:
     name: deploy
     runs-on: ubuntu-latest
-  
+    environment: mainnet
     permissions:
       contents: read
       id-token: write
       actions: write
-  
+    env:
+      AWS_REGION: '${{ secrets.AWS_REGION }}'
+      AWS_MAINNET: '${{ secrets.AWS_MAINNET }}'
     steps:
       - name: Authorised User only
         run: |

--- a/.github/workflows/deploy_mainnet.yml
+++ b/.github/workflows/deploy_mainnet.yml
@@ -56,7 +56,7 @@ jobs:
             awsRegion=${{ env.AWS_REGION }}
             awsEnv=${{ env.ENVIRONMENT }}
             imageTag=${{ env.VERSION }}
-            awsEfs=${{ secrets.SPECTRE_EFS_MAINNET }}
+            awsEfs=${{ secrets.SPECTRE_EFS }}
   
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -7,12 +7,13 @@ on:
   push:
     branches:
       - main
-      
+
+run-name: Deploy Spectre Node to Testnet - ${{ inputs.release_tag }} by @${{ github.actor }}
+
 env:
   ENVIRONMENT: 'TESTNET'
   REGISTRY: 'ghcr.io'
   TAG: 'latest'
-  AWS_TESTNET: '${{ secrets.AWS_ARN }}'
 
 jobs:
   push:
@@ -60,13 +61,16 @@ jobs:
     needs: push
     name: deploy
     runs-on: ubuntu-latest
+    environment: testnet
     strategy:
       matrix:
         spectre_id: [0]
-
     permissions:
       contents: read
       id-token: write
+    env: 
+      AWS_TESTNET: '${{ secrets.AWS_TESTNET }}'
+      AWS_REGION: '${{ secrets.AWS_REGION }}'
 
     steps:
       - name: checkout ecs repo
@@ -84,7 +88,7 @@ jobs:
           variables: |
             spectreId=${{ matrix.spectre_id }}
             awsAccountId=${{ env.AWS_TESTNET }}
-            awsRegion=${{ secrets.AWS_REGION }}
+            awsRegion=${{ env.AWS_REGION }}
             awsEfs=${{ secrets.SPECTRE_EFS_TESTNET }}
             imageTag=${{ github.ref_name }}
 
@@ -92,7 +96,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: arn:aws:iam::${{ env.AWS_TESTNET }}:role/github-actions-${{ env.ENVIRONMENT }}-chainbridge
-          aws-region: ${{ secrets.AWS_REGION }}
+          aws-region: ${{ env.AWS_REGION }}
           role-session-name: GithubActions
 
       - name: deploy task definition

--- a/.github/workflows/deploy_testnet.yml
+++ b/.github/workflows/deploy_testnet.yml
@@ -89,7 +89,7 @@ jobs:
             spectreId=${{ matrix.spectre_id }}
             awsAccountId=${{ env.AWS_TESTNET }}
             awsRegion=${{ env.AWS_REGION }}
-            awsEfs=${{ secrets.SPECTRE_EFS_TESTNET }}
+            awsEfs=${{ secrets.SPECTRE_EFS }}
             imageTag=${{ github.ref_name }}
 
       - name: configure aws credentials


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a separation of secrets from repository-wide to environment-specific.

- Secrets can be accessed based on environments
- Review is required for deployment to Mainnet
- Added Deployment Authorisation To Mainnet

Related: #[528](https://github.com/sygmaprotocol/devops/issues/528#issue-2539000686)

## How Has This Been Tested? Testing details.
Yes. for repos such as Sprinter, Sygma-relayer, Explorer, inclusion-prover

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation
